### PR TITLE
bugfix/update sklearn to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 h5py >= 2.8
 scipy
-sklearn
+scikit-learn
 numpy
 plotly
 matplotlib


### PR DESCRIPTION
Update to requirements file, as sklearn is on a brownout schedule

pip install sklearn is on a brownout schedule (https://pypi.org/project/sklearn/) and the library recommends using `scikit-learn` instead