### PR TITLE
Replace `os.path` with `pathlib.Path` in diffcrash

### DIFF
--- a/lasso/femzip/femzip_api.py
+++ b/lasso/femzip/femzip_api.py
@@ -209,7 +209,7 @@ class FemzipAPI:
     _api: Union[None, CDLL] = None
 
     @staticmethod
-    def load_dynamic_library(path: str) -> CDLL:
+    def load_dynamic_library(path: Path) -> CDLL:
         """Load a library and check for correct execution
 
         Parameters


### PR DESCRIPTION
This PR refactors the code in `diffcrash` to replace all instances of `os.path` with `pathlib.Path`. The use of os.path is considered less modern compared to pathlib.Path, which was introduced in `Python 3.4`. pathlib is now the preferred way to handle filesystem paths in modern Python code.