### PR TITLE
Using ruff for linting #04

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,32 +73,39 @@ isort.lines-after-imports = 2
 select = [
     "C",   # Complexity checks (e.g., McCabe complexity, comprehensions)
     # "ANN001", "ANN201", "ANN401", # flake8-annotations (required strict type annotations for public functions)
-    # "S",   # flake8-bandit (checks basic security issues in code)
+    "S",   # flake8-bandit (checks basic security issues in code)
     # "BLE", # flake8-blind-except (checks the except blocks that do not specify exception)
     # "FBT", # flake8-boolean-trap (ensure that boolean args can be used with kw only)
-    # "E",   # pycodestyle errors (PEP 8 style guide violations)
+    "E",   # pycodestyle errors (PEP 8 style guide violations)
     "W",   # pycodestyle warnings (e.g., extra spaces, indentation issues)
     # "DOC", # pydoclint issues (e.g., extra or missing return, yield, warnings)
-    # "A",   # flake8-buitins (check variable and function names to not shadow builtins)
-    # "N",   # Naming convention checks (e.g., PEP 8 variable and function names)
+    "A",   # flake8-buitins (check variable and function names to not shadow builtins)
+    "N",   # Naming convention checks (e.g., PEP 8 variable and function names)
     "F",   # Pyflakes errors (e.g., unused imports, undefined variables)
-    # "I",   # isort (Ensures imports are sorted properly)
-    # "B",   # flake8-bugbear (Detects likely bugs and bad practices)
+    "I",   # isort (Ensures imports are sorted properly)
+    "B",   # flake8-bugbear (Detects likely bugs and bad practices)
     "TID", # flake8-tidy-imports (Checks for banned or misplaced imports)
     "UP",  # pyupgrade (Automatically updates old Python syntax)
-    # "YTT", # flake8-2020 (Detects outdated Python 2/3 compatibility issues)
-    # "FLY", # flynt (Converts old-style string formatting to f-strings)
-    # "PIE", # flake8-pie
+    "YTT", # flake8-2020 (Detects outdated Python 2/3 compatibility issues)
+    "FLY", # flynt (Converts old-style string formatting to f-strings)
+    "PIE", # flake8-pie
     # "PL",  # pylint
     # "RUF", # Ruff-specific rules (Additional optimizations and best practices)
 ]
 
 ignore = [
-    "PLR2004",  # [magic-value-comparision](https://docs.astral.sh/ruff/rules/magic-value-comparison)
     "C90",      # [mccabe](https://docs.astral.sh/ruff/rules/#mccabe-c90)
+    "PLR2004",  # [magic-value-comparision](https://docs.astral.sh/ruff/rules/magic-value-comparison)
+    "S311",     # [suspicious-non-cryptographic-random-usage](https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/)
+    "S404",     # [suspicious-subprocess-import](https://docs.astral.sh/ruff/rules/suspicious-subprocess-import/)
+    "S603",     # [subprocess-without-shell-equals-true](https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/)
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# non-lowercase-variable-in-function (N806)
+"{femzip_api,femzip_mapper,d3plot,}.py" = ["N806"]
+# error-suffix-on-exception-name (N818)
+"{femzip_api}.py" = ["N818"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/src/lasso/__init__.py
+++ b/src/lasso/__init__.py
@@ -1,4 +1,5 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
+
 
 try:
     __version__ = version("lasso-python")

--- a/src/lasso/diffcrash/__init__.py
+++ b/src/lasso/diffcrash/__init__.py
@@ -1,3 +1,4 @@
 from .diffcrash_run import DiffcrashRun
 
+
 __all__ = ["DiffcrashRun"]

--- a/src/lasso/diffcrash/diffcrash_run.py
+++ b/src/lasso/diffcrash/diffcrash_run.py
@@ -10,12 +10,13 @@ import sys
 import time
 import typing
 from concurrent import futures
-from typing import Union
 from pathlib import Path
+from typing import Union
+
 import psutil
 
-# from ..logging import str_error, str_info, str_running, str_success, str_warn
 from lasso.logging import str_error, str_info, str_running, str_success, str_warn
+
 
 # pylint: disable = too-many-lines
 
@@ -337,9 +338,7 @@ class DiffcrashRun:
         self.logger.info(self._msg_option.format("crash-code", crash_code))
 
         if not crash_code_ok:
-            err_msg = (
-                f"Invalid crash code '{crash_code}'. Please use one of: {str(valid_crash_codes)}"
-            )
+            err_msg = f"Invalid crash code '{crash_code}'. Please use one of: {valid_crash_codes!s}"
             self.logger.error(err_msg)
             raise RuntimeError(str_error(err_msg))
 
@@ -647,22 +646,21 @@ class DiffcrashRun:
                         str(i_filepath + counter_offset),
                     ]
             # indeed there is a parameter file
+            elif self.use_id_mapping:
+                args = [
+                    self.diffcrash_home / f"DFC_Import_{self.crash_code}",
+                    "-ID",
+                    self.simulation_runs[i_filepath],
+                    self.project_dir,
+                    str(i_filepath + counter_offset),
+                ]
             else:
-                if self.use_id_mapping:
-                    args = [
-                        self.diffcrash_home / f"DFC_Import_{self.crash_code}",
-                        "-ID",
-                        self.simulation_runs[i_filepath],
-                        self.project_dir,
-                        str(i_filepath + counter_offset),
-                    ]
-                else:
-                    args = [
-                        self.diffcrash_home / f"DFC_Import_{self.crash_code}",
-                        self.simulation_runs[i_filepath],
-                        self.project_dir,
-                        str(i_filepath + counter_offset),
-                    ]
+                args = [
+                    self.diffcrash_home / f"DFC_Import_{self.crash_code}",
+                    self.simulation_runs[i_filepath],
+                    self.project_dir,
+                    str(i_filepath + counter_offset),
+                ]
 
             # append args to list
             import_arguments.append(args)
@@ -689,7 +687,11 @@ class DiffcrashRun:
 
             if n_imports_finished != n_new_imports_finished:
                 # pylint: disable = consider-using-f-string
-                msg = f"Running Imports ... [{n_new_imports_finished}/{len(return_code_futures)}] - {percentage:3.2f}%\r"
+                msg = (
+                    f"Running Imports ... [{n_new_imports_finished}/{len(return_code_futures)}] - "
+                    f"{percentage:3.2f}%\r"
+                )
+
                 print(str_running(msg), end="", flush=True)
                 self.logger.info(msg)
 
@@ -1206,7 +1208,7 @@ class DiffcrashRun:
             conf_lines = conf.readlines()
         line = 0
 
-        for i in range(0, len(conf_lines)):
+        for i in range(len(conf_lines)):
             if conf_lines[i].find("FUNCTION") >= 0:
                 line = i + 1
                 break
@@ -1216,7 +1218,7 @@ class DiffcrashRun:
         if line != 0:
             while 1:
                 while 1:
-                    for i in range(0, len(conf_lines[line])):
+                    for i in range(len(conf_lines[line])):
                         if conf_lines[line][i] == "<":
                             element_start = i + 1
                         if conf_lines[line][i] == ">":
@@ -1231,7 +1233,7 @@ class DiffcrashRun:
                     j += 1
                     items = check.split(" ")
                     pos = -1
-                    for n in range(0, len(items)):
+                    for n in range(len(items)):
                         if items[n].startswith("!"):
                             msg = f"FOUND at {n}"
                             print(msg)
@@ -1240,7 +1242,7 @@ class DiffcrashRun:
                             break
                         pos = len(items)
 
-                    for n in range(0, pos):
+                    for n in range(pos):
                         if items[n] == "PDMX" or items[n] == "pdmx":
                             break
                         if items[n] == "PDXMX" or items[n] == "pdxmx":
@@ -1262,7 +1264,7 @@ class DiffcrashRun:
 
                     for k in range(n, pos):
                         postval = None
-                        for m in range(0, n):
+                        for m in range(n):
                             if items[m] == "coordinates":
                                 items[m] = "geometry"
                             if postval is None:

--- a/src/lasso/diffcrash/run.py
+++ b/src/lasso/diffcrash/run.py
@@ -12,7 +12,6 @@ from lasso.diffcrash.diffcrash_run import (
     DiffcrashRun,
     parse_diffcrash_args,
 )
-
 from lasso.logging import str_error
 
 

--- a/src/lasso/dimred/__init__.py
+++ b/src/lasso/dimred/__init__.py
@@ -1,3 +1,4 @@
 from .dimred_run import DimredRun, DimredStage
 
+
 __all__ = ["DimredRun", "DimredStage"]

--- a/src/lasso/dimred/graph_laplacian.py
+++ b/src/lasso/dimred/graph_laplacian.py
@@ -76,7 +76,8 @@ def _laplacian_gauss_idw(
     L: array-like, shape (n_points, n_points)
       The laplacian matrix for manifold given by its sampling `points`.
     """
-    assert 2 == points.ndim
+    if points.ndim != 2:
+        raise TypeError("Only 2D arrays are supported.")
 
     if min_neighbors is None:
         min_neighbors = points.shape[1]
@@ -110,7 +111,8 @@ def _laplacian_gauss_idw(
         graph[i, j] = d = np.exp(d)
         graph[j, i] = d[:, np.newaxis]
 
-    assert 0 == (graph != graph.T).sum()
+    if not np.array_equal(graph, graph.T):
+        raise RuntimeError("graph matrix is not symetric.")
 
     return csgraph.laplacian(graph, normed=True)
 

--- a/src/lasso/dimred/hashing.py
+++ b/src/lasso/dimred/hashing.py
@@ -1,8 +1,8 @@
 import multiprocessing
 import os
 import time
-from typing import Union
 from collections.abc import Sequence
+from typing import Union
 
 import h5py
 import numpy as np
@@ -83,7 +83,10 @@ def is_orientation_flip_required(eigenvectors1: np.ndarray, eigenvectors2: np.nd
         The eigenmodes require switching if the dot product of the knn-eigenfields yield
         a negative result.
     """
-    assert eigenvectors1.shape == eigenvectors2.shape
+    if eigenvectors1.shape != eigenvectors2.shape:
+        raise AssertionError(
+            f"shape mismatch detected. {eigenvectors1.shape} not equal to {eigenvectors2.shape}"
+        )
 
     # one eigenmode only
     if eigenvectors1.ndim == 1:
@@ -133,7 +136,10 @@ def _compute_mode_similarities(
 
     mode_similarities = []
     for i_hash, j_hash in matches:
-        assert hashes1.shape[2] == hashes2.shape[2]
+        if hashes1.shape[2] != hashes2.shape[2]:
+            raise AssertionError(
+                f"Unequal number of columns. {hashes1.shape[2]} is not equal to {hashes2.shape[2]}"
+            )
 
         field1 = eigenvectors_sub1[:, i_hash]
         field2 = eigenvectors_sub2[:, j_hash]
@@ -238,7 +244,8 @@ def run_hash_comparison(
 
     # pylint: disable = too-many-locals, too-many-statements
 
-    assert n_threads > 0
+    if n_threads <= 0:
+        raise ValueError("Number of threads cannot be negative or zero.")
 
     # fixed settings
     hdf5_dataset_compression = "gzip"
@@ -621,7 +628,11 @@ def compute_hashes(
         For comparison, only y is usually used.
     """
 
-    assert eig_vecs.shape[0] == len(result_field), f"{eig_vecs.shape[0]} != {len(result_field)}"
+    if eig_vecs.shape[0] != len(result_field):
+        raise AssertionError(
+            f"Unequal number of rows detected. {eig_vecs.shape[0]} "
+            f"is not equal to {len(result_field)}"
+        )
 
     # Note: needs to be vectorized to speed it up
 

--- a/src/lasso/dimred/hashing_sphere.py
+++ b/src/lasso/dimred/hashing_sphere.py
@@ -11,6 +11,7 @@ from scipy.spatial import ConvexHull
 from scipy.stats import binned_statistic_2d
 from sklearn.preprocessing import normalize
 
+
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
@@ -31,7 +32,8 @@ def _create_sphere_mesh(diameter: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         beta bin boundaries
     """
 
-    assert diameter.dtype == np.float32
+    if diameter.dtype != np.float32:
+        raise TypeError("diameter array must be of type `np.float32`.")
 
     # partition latitude
     n_alpha = 145
@@ -59,8 +61,7 @@ def _create_sphere_mesh(diameter: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     bin_beta = 1 - tmp
 
     # In case of trailing floats (-1.00000004 for example)
-    if bin_beta[-1] < -1:
-        bin_beta[-1] = -1
+    bin_beta[-1] = max(bin_beta[-1], -1)
 
     bin_beta = np.arccos(bin_beta)
 
@@ -139,10 +140,16 @@ def sphere_hashing(
     """
     # bin_numbers holds the bin_number for its respective index and must have
     # same length as the number of points
-    assert len(bin_numbers[0] == len(field))
+    if not len(bin_numbers[0] == len(field)):
+        raise AssertionError(
+            "bin_numbers holds the bin_number for its respective index and"
+            "must have same length as the number of points."
+        )
     # check data types
-    assert bin_numbers.dtype == np.int
-    assert bin_counts.dtype == np.float32
+    if not np.issubdtype(bin_numbers.dtype, np.integer):
+        raise TypeError(f"Expected int dtype got {bin_numbers.dtype}")
+    if not np.issubdtype(bin_counts.dtype, np.floating):
+        raise TypeError(f"Expected float dtype got {bin_counts.dtype}.")
 
     n_rows = bin_counts.shape[0]
     n_cols = bin_counts.shape[1]

--- a/src/lasso/dimred/sphere/algorithms.py
+++ b/src/lasso/dimred/sphere/algorithms.py
@@ -1,13 +1,12 @@
 import numpy as np
 
-from sklearn.preprocessing import normalize
-
 # scipy is C-code which causes invalid linter warning about ConvexHull not
 # being around.
 # pylint: disable = no-name-in-module
 from scipy.spatial import ConvexHull
 from scipy.stats import binned_statistic_2d
 from scipy.stats._binned_statistic import BinnedStatistic2dResult
+from sklearn.preprocessing import normalize
 
 
 def to_spherical_coordinates(points: np.ndarray, centroid: np.ndarray, axis: str = "Z"):
@@ -78,7 +77,11 @@ def sphere_hashing(histo: BinnedStatistic2dResult, field: np.ndarray):
     """
     bin_n = histo.binnumber
 
-    assert len(bin_n[0] == len(field))
+    if not len(bin_n[0] == len(field)):
+        raise AssertionError(
+            "bin_numbers holds the bin_number for its respective index and"
+            "must have same length as the number of points."
+        )
 
     # get dims of the embedding space
     n_rows = histo.statistic.shape[0]
@@ -150,8 +153,7 @@ def create_sphere(diameter: float):
     tmp = count * a_ele
     tmp /= r**2 * delt_alpha
     bin_beta = 1 - tmp
-    if bin_beta[-1] < -1:
-        bin_beta[-1] = -1
+    bin_beta[-1] = max(bin_beta[-1], -1)
 
     bin_beta = np.arccos(bin_beta)
     return bin_alpha, bin_beta

--- a/src/lasso/dimred/svd/clustering_betas.py
+++ b/src/lasso/dimred/svd/clustering_betas.py
@@ -1,5 +1,5 @@
-from typing import Union
 from collections.abc import Sequence
+from typing import Union
 
 import numpy as np
 from sklearn.cluster import DBSCAN, OPTICS, KMeans, SpectralClustering
@@ -355,7 +355,8 @@ def __rescale_betas(betas):
     maxb: np.ndarray
         Array to rescale betas back to original values
     """
-    assert len(betas.shape) == 2
+    if len(betas.shape) != 2:
+        raise TypeError("only 2D arrays are supported.")
     ref_betas = np.abs(betas)
     maxb = np.array([np.max(ref_betas[:, i]) for i in range(betas.shape[1])])
     # return np.array([(betas[:, i]/maxb[i]) for i in range(betas.shape[1])]).T

--- a/src/lasso/dimred/svd/plot_beta_clusters.py
+++ b/src/lasso/dimred/svd/plot_beta_clusters.py
@@ -2,8 +2,8 @@ import os
 import re
 import time
 import webbrowser
-from typing import Union
 from collections.abc import Sequence
+from typing import Union
 
 import numpy as np
 

--- a/src/lasso/dimred/svd/pod_functions.py
+++ b/src/lasso/dimred/svd/pod_functions.py
@@ -1,9 +1,9 @@
 from typing import Union
 
 import numpy as np
+from rich.progress import Progress, TaskID
 from scipy.sparse import csc_matrix
 from scipy.sparse.linalg import svds
-from rich.progress import Progress, TaskID
 
 from lasso.utils.rich_progress_bars import PlaceHolderBar
 

--- a/src/lasso/dimred/svd/subsampling_methods.py
+++ b/src/lasso/dimred/svd/subsampling_methods.py
@@ -1,8 +1,8 @@
 import os
 import random
 import time
-from typing import Union
 from collections.abc import Sequence
+from typing import Union
 
 import numpy as np
 from sklearn.neighbors import NearestNeighbors

--- a/src/lasso/dyna/__init__.py
+++ b/src/lasso/dyna/__init__.py
@@ -1,7 +1,8 @@
-from .d3plot import D3plot
-from .binout import Binout
 from .array_type import ArrayType
+from .binout import Binout
+from .d3plot import D3plot
+from .d3plot_header import D3plotFiletype, D3plotHeader
 from .filter_type import FilterType
-from .d3plot_header import D3plotHeader, D3plotFiletype
+
 
 __all__ = ["Binout", "D3plot", "ArrayType", "FilterType", "D3plotHeader", "D3plotFiletype"]

--- a/src/lasso/dyna/d3plot_header.py
+++ b/src/lasso/dyna/d3plot_header.py
@@ -7,6 +7,7 @@ import rich
 from lasso.io.binary_buffer import BinaryBuffer
 from lasso.logging import get_logger
 
+
 # We have a lot of docstrings here but even if not so, we want to contain the
 # code here.
 # pylint: disable=too-many-lines
@@ -883,35 +884,34 @@ class D3plotHeader:
         self.has_solid_shell_thermal_strain_tensor = get_digit(self.raw_header["idtdt"], 3) == 1
         if self.raw_header["idtdt"] > 100:
             self.has_element_strain = get_digit(self.raw_header["idtdt"], 4) == 1
-        else:
-            # took a 1000 years to figure this out ...
-            # Warning: 4 gaussian points are not considered
-            if self.n_shell_vars > 0:
-                if (
-                    self.n_shell_vars
-                    - self.n_shell_tshell_layers
-                    * (
-                        6 * self.has_shell_tshell_stress
-                        + self.has_shell_tshell_pstrain
-                        + self.n_shell_tshell_history_vars
-                    )
-                    - 8 * self.has_shell_forces
-                    - 4 * self.has_shell_extra_variables
-                ) > 1:
-                    self.has_element_strain = True
-                # else:
-                # self.has_element_strain = False
-            elif self.n_thick_shell_vars > 0:
-                if (
-                    self.n_thick_shell_vars
-                    - self.n_shell_tshell_layers
-                    * (
-                        6 * self.has_shell_tshell_stress
-                        + self.has_shell_tshell_pstrain
-                        + self.n_shell_tshell_history_vars
-                    )
-                ) > 1:
-                    self.has_element_strain = True
+        # took a 1000 years to figure this out ...
+        # Warning: 4 gaussian points are not considered
+        elif self.n_shell_vars > 0:
+            if (
+                self.n_shell_vars
+                - self.n_shell_tshell_layers
+                * (
+                    6 * self.has_shell_tshell_stress
+                    + self.has_shell_tshell_pstrain
+                    + self.n_shell_tshell_history_vars
+                )
+                - 8 * self.has_shell_forces
+                - 4 * self.has_shell_extra_variables
+            ) > 1:
+                self.has_element_strain = True
+            # else:
+            # self.has_element_strain = False
+        elif self.n_thick_shell_vars > 0:
+            if (
+                self.n_thick_shell_vars
+                - self.n_shell_tshell_layers
+                * (
+                    6 * self.has_shell_tshell_stress
+                    + self.has_shell_tshell_pstrain
+                    + self.n_shell_tshell_history_vars
+                )
+            ) > 1:
+                self.has_element_strain = True
                 # else:
                 #     self.has_element_strain = False
             # else:
@@ -1085,7 +1085,7 @@ class D3plotHeader:
                 storage_dict[name] = int(bb.read_number(data[0], data[1]))
             elif data[1] == self.ftype:
                 storage_dict[name] = float(bb.read_number(data[0], data[1]))
-            elif data[1] == str:
+            elif data[1] is str:
                 try:
                     storage_dict[name] = bb.read_text(data[0], data[2])
                 except UnicodeDecodeError:
@@ -1182,7 +1182,11 @@ class D3plotHeader:
         differences: Dict[str, Tuple[Any, Any]]
             The different entries of both headers in a dict
         """
-        assert isinstance(other, D3plotHeader)
+        if not isinstance(other, D3plotHeader):
+            raise TypeError(
+                "Only D3plotHeaders instances are supported. "
+                f"Detected {type(other)} is unsupported."
+            )
 
         differences = {}
         names = {*self.raw_header.keys(), *other.raw_header.keys()}

--- a/src/lasso/dyna/femzip_mapper.py
+++ b/src/lasso/dyna/femzip_mapper.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Union
 
 import numpy as np
+
 from lasso.dyna.array_type import ArrayType
 from lasso.femzip.femzip_api import FemzipAPI, FemzipFileMetadata, VariableInfo
 from lasso.femzip.fz_config import FemzipArrayType, FemzipVariableCategory, get_last_int_of_line

--- a/src/lasso/femzip/__init__.py
+++ b/src/lasso/femzip/__init__.py
@@ -1,3 +1,4 @@
 from .femzip_api import FemzipAPI
 
+
 __all__ = ["FemzipAPI"]

--- a/src/lasso/femzip/femzip_api.py
+++ b/src/lasso/femzip/femzip_api.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from pathlib import Path
 import re
 import stat
 import sys
@@ -18,11 +17,13 @@ from ctypes import (
     c_uint64,
     sizeof,
 )
+from pathlib import Path
 from typing import Any, Union
 
 import numpy as np
 
 from .fz_config import FemzipArrayType, FemzipVariableCategory, get_last_int_of_line
+
 
 # During next refactoring we should take a look at reducing the file size.
 # pylint: disable = too-many-lines
@@ -441,7 +442,10 @@ class FemzipAPI:
         """
         # We access some internal members to do some magic.
         # pylint: disable = protected-access
-        assert src._fields_ == dest._fields_
+        if src._fields_ != dest._fields_:
+            raise ValueError(
+                f"Source and destination fields do not match: {src._fields_} != {dest._fields_}"
+            )
 
         for field_name, _ in src._fields_:
             setattr(dest, field_name, getattr(src, field_name))
@@ -1284,7 +1288,10 @@ class FemzipAPI:
         return file_metadata2
 
 
-class FemzipD3plotArrayMapping:
+# NOTE: class-as-data-structure (B903)
+# Class could be dataclass or namedtuple
+# See: https://docs.astral.sh/ruff/rules/class-as-data-structure/
+class FemzipD3plotArrayMapping:  # noqa B903
     """Contains information about how to map femzip arrays to d3plot arrays"""
 
     d3plot_array_type: str

--- a/src/lasso/femzip/fz_config.py
+++ b/src/lasso/femzip/fz_config.py
@@ -1,6 +1,5 @@
-from typing import Union
-
 import enum
+from typing import Union
 
 
 def get_last_int_of_line(line: str) -> tuple[str, Union[None, int]]:

--- a/src/lasso/io/binary_buffer.py
+++ b/src/lasso/io/binary_buffer.py
@@ -46,7 +46,9 @@ class BinaryBuffer:
         new_mv: memoryview
             memoryview used to store the bytes
         """
-        assert isinstance(new_mv, memoryview)
+        if not isinstance(new_mv, memoryview):
+            raise TypeError(f"new_mv must be a memoryview, got {type(new_mv)}")
+
         self.mv_ = new_mv
         self.sizes_ = [len(self.mv_)]
 
@@ -68,8 +70,11 @@ class BinaryBuffer:
             the slice as a new buffer
         """
 
-        assert start < len(self)
-        assert end is None or end < len(self)
+        if start >= len(self):
+            raise IndexError(f"start index {start} out of range (length {len(self)})")
+
+        if end is not None and end >= len(self):
+            raise IndexError(f"end index {end} out of range (length {len(self)})")
 
         end = len(self) if end is None else end
 
@@ -283,7 +288,10 @@ class BinaryBuffer:
             buffer to append
         """
 
-        assert isinstance(binary_buffer, BinaryBuffer)
+        if not isinstance(binary_buffer, BinaryBuffer):
+            raise TypeError(
+                f"binary_buffer must be an instance of BinaryBuffer, got {type(binary_buffer)}"
+            )
 
         self.mv_ = memoryview(bytearray(self.mv_) + bytearray(binary_buffer.mv_))
         self.sizes_.append(len(binary_buffer))

--- a/src/lasso/io/files.py
+++ b/src/lasso/io/files.py
@@ -2,8 +2,8 @@ import contextlib
 import glob
 import os
 import typing
-from typing import Union
 from collections.abc import Iterator
+from typing import Union
 
 
 @contextlib.contextmanager

--- a/src/lasso/logging.py
+++ b/src/lasso/logging.py
@@ -3,6 +3,7 @@ import platform
 
 from lasso.utils.console_coloring import ConsoleColoring
 
+
 # settings
 MARKER_INFO = "[/]"
 MARKER_RUNNING = "[~]"

--- a/src/lasso/math/sampling.py
+++ b/src/lasso/math/sampling.py
@@ -1,5 +1,6 @@
 import random
 from typing import Union
+
 import numpy as np
 from sklearn.neighbors import KDTree
 
@@ -23,7 +24,10 @@ def unique_subsamples(start: int, end: int, n_samples: int, seed=None) -> np.nda
     indexes: np.ndarray
         unique sample indexes
     """
-    assert start <= end
+    if start > end:
+        raise ValueError(
+            f"Invalid range: start ({start}) must be less than or equal to end ({end})"
+        )
 
     n_samples = min(n_samples, end - start)
     random.seed(seed)

--- a/src/lasso/plotting/__init__.py
+++ b/src/lasso/plotting/__init__.py
@@ -1,3 +1,4 @@
 from .plot_shell_mesh import plot_shell_mesh
 
+
 __all__ = ["plot_shell_mesh"]

--- a/src/lasso/plotting/plot_shell_mesh.py
+++ b/src/lasso/plotting/plot_shell_mesh.py
@@ -1,10 +1,11 @@
-import os
 import io
-import uuid
 import json
+import os
+import uuid
 from base64 import b64encode
-from zipfile import ZipFile, ZIP_DEFLATED
 from typing import Union
+from zipfile import ZIP_DEFLATED, ZipFile
+
 import numpy as np
 
 
@@ -55,16 +56,48 @@ def plot_shell_mesh(
 
     # pylint: disable = too-many-locals, too-many-statements
 
-    assert node_coordinates.ndim == 2
-    assert node_coordinates.shape[1] == 3
-    assert shell_node_indexes.ndim == 2
-    assert shell_node_indexes.shape[1] in [3, 4]
+    if getattr(node_coordinates, "ndim", None) != 2:
+        raise ValueError(
+            f"node_coordinates must be 2-dimensional, "
+            f"got ndim={getattr(node_coordinates, 'ndim', 'unknown')}"
+        )
+
+    if getattr(node_coordinates, "shape", (None, None))[1] != 3:
+        raise ValueError(
+            f"node_coordinates must have shape[1] == 3, "
+            f"got shape={getattr(node_coordinates, 'shape', 'unknown')}"
+        )
+
+    if getattr(shell_node_indexes, "ndim", None) != 2:
+        raise ValueError(
+            f"shell_node_indexes must be 2-dimensional, "
+            f"got ndim={getattr(shell_node_indexes, 'ndim', 'unknown')}"
+        )
+
+    shape_1 = getattr(shell_node_indexes, "shape", (None, None))[1]
+    if shape_1 not in (3, 4):
+        raise ValueError(f"shell_node_indexes must have shape[1] of 3 or 4, got shape[1]={shape_1}")
+
     if isinstance(field, np.ndarray):
-        assert field.ndim == 1
+        if getattr(field, "ndim", None) != 1:
+            raise ValueError(
+                f"field must be 1-dimensional, got ndim={getattr(field, 'ndim', 'unknown')}"
+            )
+
         if is_element_field:
-            assert field.shape[0] == shell_node_indexes.shape[0]
-        else:
-            assert field.shape[0] == node_coordinates.shape[0]
+            if (
+                getattr(field, "shape", (None,))[0]
+                != getattr(shell_node_indexes, "shape", (None,))[0]
+            ):
+                raise ValueError(
+                    f"field length {getattr(field, 'shape', (None,))[0]} does not match "
+                    f"shell_node_indexes length {getattr(shell_node_indexes, 'shape', (None,))[0]}"
+                )
+        elif getattr(field, "shape", (None,))[0] != getattr(node_coordinates, "shape", (None,))[0]:
+            raise ValueError(
+                f"field length {getattr(field, 'shape', (None,))[0]} does not match "
+                f"node_coordinates length {getattr(node_coordinates, 'shape', (None,))[0]}"
+            )
 
     # cast types correctly
     # the types MUST be float32

--- a/src/lasso/utils/language.py
+++ b/src/lasso/utils/language.py
@@ -47,10 +47,9 @@ def set_var(name, value, context):
         if i_name == len(name) - 1:
             current_context[current_name] = value
         # otherwise iterate into next level
+        elif current_name in current_context:
+            current_context = current_context[current_name]
         else:
-            if current_name in current_context:
-                current_context = current_context[current_name]
-            else:
-                new_level = {}
-                current_context[current_name] = new_level
-                current_context = new_level
+            new_level = {}
+            current_context[current_name] = new_level
+            current_context = new_level

--- a/test/unit_tests/dimred/svd/test_clustering_betas.py
+++ b/test/unit_tests/dimred/svd/test_clustering_betas.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
+
 import numpy as np
+
 from lasso.dimred.svd.clustering_betas import group_betas
-from lasso.dimred.svd.keyword_types import DetectorType, ClusterType
+from lasso.dimred.svd.keyword_types import ClusterType, DetectorType
 
 
 class TestClustering(TestCase):

--- a/test/unit_tests/dimred/svd/test_plot_betas_clusters.py
+++ b/test/unit_tests/dimred/svd/test_plot_betas_clusters.py
@@ -2,6 +2,7 @@ import hashlib
 from unittest import TestCase
 
 import numpy as np
+
 from lasso.dimred.svd.plot_beta_clusters import plot_clusters_js
 
 

--- a/test/unit_tests/dimred/svd/test_pod_functions.py
+++ b/test/unit_tests/dimred/svd/test_pod_functions.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
-from lasso.dimred.svd.pod_functions import calculate_v_and_betas
+
 import numpy as np
+
+from lasso.dimred.svd.pod_functions import calculate_v_and_betas
 
 
 class PodFunctionsTest(TestCase):

--- a/test/unit_tests/dyna/test_d3plot.py
+++ b/test/unit_tests/dyna/test_d3plot.py
@@ -1,14 +1,14 @@
 import os
+import struct
 import tempfile
-from lasso.io.binary_buffer import BinaryBuffer
-from lasso.femzip.femzip_api import FemzipAPI
 from unittest import TestCase
 
-import struct
 import numpy as np
 
-from lasso.dyna.d3plot import D3plot, FilterType, _negative_to_positive_state_indexes
 from lasso.dyna.array_type import ArrayType
+from lasso.dyna.d3plot import D3plot, FilterType, _negative_to_positive_state_indexes
+from lasso.femzip.femzip_api import FemzipAPI
+from lasso.io.binary_buffer import BinaryBuffer
 
 
 class D3plotTest(TestCase):

--- a/test/unit_tests/dyna/test_d3plot_header.py
+++ b/test/unit_tests/dyna/test_d3plot_header.py
@@ -1,7 +1,8 @@
+import warnings
 from unittest import TestCase
 
 import numpy as np
-import warnings
+
 from lasso.dyna.d3plot_header import (
     D3plotFiletype,
     D3plotHeader,
@@ -24,7 +25,7 @@ class D3plotHeaderTest(TestCase):
             D3plotHeader().load_file(filepath)
 
         # TODO more
-        warnings.warn("No assertions of behavior, test is incomplete")
+        warnings.warn(message="No assertions of behavior, test is incomplete", stacklevel=2)
 
     def test_get_digit(self) -> None:
         number = 1234567890

--- a/test/unit_tests/dyna/test_mapper.py
+++ b/test/unit_tests/dyna/test_mapper.py
@@ -3,9 +3,10 @@ from unittest import TestCase
 
 import numpy as np
 
-from lasso.femzip.fz_config import FemzipArrayType, FemzipVariableCategory
 from lasso.dyna.array_type import ArrayType
 from lasso.dyna.femzip_mapper import FemzipMapper
+from lasso.femzip.fz_config import FemzipArrayType, FemzipVariableCategory
+
 
 part_global_femzip_translations: dict[tuple[FemzipArrayType, FemzipVariableCategory], set[str]] = {
     # GLOBAL
@@ -256,7 +257,7 @@ class MapperTest(TestCase):
         self,
         fz: dict[tuple[str, FemzipVariableCategory], np.ndarray],
         d3plot_shape: tuple,
-        data_index_positions: Union[tuple, slice] = slice(None),
+        data_index_positions: Union[tuple, slice] = None,
     ):
         """Validate that the arrays have the same shape and that the
         raw data has been allocated to the correct positions in the
@@ -271,6 +272,8 @@ class MapperTest(TestCase):
         data_index_positions:
             positions of the raw data in the d3plot array
         """
+        if data_index_positions is None:
+            data_index_positions = slice(None)
         d3plot_name = []
 
         m = FemzipMapper()

--- a/test/unit_tests/io/test_binary_buffer.py
+++ b/test/unit_tests/io/test_binary_buffer.py
@@ -1,7 +1,8 @@
-import os
-import numpy as np
-from unittest import TestCase
 import filecmp
+import os
+from unittest import TestCase
+
+import numpy as np
 
 from lasso.io.binary_buffer import BinaryBuffer
 
@@ -19,7 +20,7 @@ class BinaryBufferTest(TestCase):
 
     def test_memoryview(self):
         self.assertEqual(self.bb.mv_, self.bb.memoryview)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             self.bb.memoryview = None
         self.memoryview = memoryview(bytearray(b""))
 

--- a/test/unit_tests/io/test_files.py
+++ b/test/unit_tests/io/test_files.py
@@ -1,4 +1,5 @@
 import unittest
+
 from lasso.io.files import collect_files
 
 


### PR DESCRIPTION
Update ruff lint select rules. This pull request includes follow-up modifications and refinements related to the integration of Ruff, a linter for Python. Updated rules in `pyproject.toml`:

- [`S`](https://docs.astral.sh/ruff/rules/#flake8-bandit-s) – **Security issues** (via `flake8-bandit`), such as unsafe use of functions like `eval`, `assert`, etc.
- [`E`](https://docs.astral.sh/ruff/rules/#error-e) – **PEP 8 style errors** (via `pycodestyle`)
- [`A`](https://docs.astral.sh/ruff/rules/#flake8-builtins-a) – **Built-in shadowing** (via `flake8-builtins`) to avoid overwriting Python built-in names
- [`N`](https://docs.astral.sh/ruff/rules/#pep8-naming-n) – **Naming conventions** (e.g., snake_case for functions, PascalCase for classes)
- [`I`](https://docs.astral.sh/ruff/rules/#isort-i) – **Import sorting** (via `isort`)
- [`B`](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b) – **Bug and bad practice detection** (via `flake8-bugbear`)
- [`YTT`](https://docs.astral.sh/ruff/rules/#flake8-2020-ytt) – **Outdated Python compatibility** checks (via `flake8-2020`)
- [`FLY`](https://docs.astral.sh/ruff/rules/#flynt-fly) – **f-string modernization** (via `flynt`)
- [`PIE`](https://docs.astral.sh/ruff/rules/#flake8-pie-pie) – **Miscellaneous improvements** and best practices (via `flake8-pie`)
