### PR TITLE
fix(d3plot): correct printf-style formatting in debug logs

### DIFF
--- a/src/lasso/dyna/d3plot.py
+++ b/src/lasso/dyna/d3plot.py
@@ -6228,7 +6228,7 @@ class D3plot:
         # write geometry file
         with open_file_or_filepath(filepath, "wb") as fp:
             n_bytes_written = 0
-            msg = "wrote {0} after {1}."
+            msg = "wrote %s after %s."
 
             # header
             n_bytes_written += self._write_header(fp, write_settings)
@@ -6309,7 +6309,7 @@ class D3plot:
                 n_bytes_written += fp.write(zero_bytes)
                 LOGGER.debug(msg, n_bytes_written, "_zero_byte_padding")
 
-            msg = "Wrote {0} bytes to geometry file."
+            msg = "Wrote %s bytes to geometry file."
             LOGGER.debug(msg, n_bytes_written)
 
             # Extra Data Types (for multi solver output)

--- a/test/unit_tests/dyna/test_d3plot.py
+++ b/test/unit_tests/dyna/test_d3plot.py
@@ -342,7 +342,8 @@ class D3plotTest(TestCase):
 
                     # rewrite d3plot
                     out_filepath = os.path.join(dirpath, "yay.d3plot")
-                    d3plot1.write_d3plot(out_filepath)
+                    with self.assertLogs("lasso.dyna.d3plot", level="DEBUG"):
+                        d3plot1.write_d3plot(out_filepath)
 
                     # read it in again and compare
                     d3plot2 = D3plot(out_filepath, **d3plot_kwargs)


### PR DESCRIPTION
Fix TypeError in d3plot.py debug logging

The logger was using str.format style placeholders `{0}, {1}` while passing arguments as separate parameters. This causes a `TypeError` when the log level is set to DEBUG.

Test included that fails without fix.