### PR TITLE
fix: edit setuptools setting to include femzip libs in wheel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,11 +62,10 @@ Join our open-source community on:
 Development
 -----------
 
-For development install `poetry`_ and `task`_:
+For development install `uv`_ and `task`_:
 
 ..  code-block:: bash
-
-    python -m pip install poetry
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     sh -c "$(curl --location https://taskfile.dev/install.sh)" \
         -- -d -b ~/.local/bin
 
@@ -75,5 +74,5 @@ commands such as ``task setup`` to install all dependencies or ``task test`` to
 run the test suite.
 Happy Coding 🥳🎉
 
-.. _poetry: https://python-poetry.org/
+.. _uv: https://github.com/astral-sh/uv
 .. _task: https://taskfile.dev/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.package-data]
+"lasso" = ["femzip/lib/*"]
 
 [project.scripts]
 diffcrash = "lasso.diffcrash.run:main"


### PR DESCRIPTION
Fixes https://github.com/open-lasso-python/lasso-python/issues/96
* Include package data so setuptools will include femzip lib. Currently, the femzip lib is included in the source distribution but not the wheel. Details on the setuptools rules for including data files in source distributions / wheels found here: https://setuptools.pypa.io/en/latest/userguide/datafiles.html#interplay-between-these-keywords 
* Update `README.rst` to use `uv` instead of `poetry`

Tested wheel generation and femzip locally; hard to create a unit test as there is no open src library to generate a femzip file.